### PR TITLE
Rename Docker image names and repo endpoints

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,8 +30,8 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME ==~ /(master|develop)/ || env.TAG_NAME) {
                         DOCKER_TAGS = ['master': 'latest', 'develop': 'develop']
-                        withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
-                          env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19002"
+                        withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'login', passwordVariable: 'password')]) {
+                          env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19004"
                           env.DOCKER_REGISTRY_USERNAME = "${login}"
                           env.DOCKER_REGISTRY_PASSWORD = "${password}"
                           env.TAG = env.TAG_NAME ? env.TAG_NAME : DOCKER_TAGS[env.BRANCH_NAME]

--- a/chain-adapter/build.gradle
+++ b/chain-adapter/build.gradle
@@ -38,7 +38,7 @@ shadowJar.archiveName = 'app.jar'
 
 // sora-plugin configs
 soramitsu {
-    projectGroup = 'd3-deploy'
+    projectGroup = 'soramitsu'
     docker {
         // docker tag
         tag = System.getenv("TAG")


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

- Rename `projectGroup` parameter of `sora-plugin` to `soramitsu` so that Docker images are pushed using the correct repository
- Rename Docker images repository and push credentials