### PR TITLE
Fixed executor service

### DIFF
--- a/chain-adapter-client/src/main/java/com/d3/chainadapter/client/ReliableIrohaChainListener4J.java
+++ b/chain-adapter-client/src/main/java/com/d3/chainadapter/client/ReliableIrohaChainListener4J.java
@@ -10,8 +10,6 @@ import kotlin.Unit;
 import lombok.NonNull;
 
 import java.io.Closeable;
-import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Class that wraps ReliableIrohaChainListener
@@ -21,21 +19,18 @@ public class ReliableIrohaChainListener4J implements Closeable {
     private final ReliableIrohaChainListener reliableIrohaChainListener;
 
     /**
-     * @param rmqConfig               RabbitMQ configuration
-     * @param irohaQueue              queue that will be bound to Iroha blocks exchange
-     * @param consumerExecutorService executor that is used to execure RabbitMQ consumer code.
-     * @param autoAck                 turns on/off auto acknowledgment mode
-     * @param onRMQFail               function that will be called on RabbitMQ failure
+     * @param rmqConfig  RabbitMQ configuration
+     * @param irohaQueue queue that will be bound to Iroha blocks exchange
+     * @param autoAck    turns on/off auto acknowledgment mode
+     * @param onRMQFail  function that will be called on RabbitMQ failure
      */
     public ReliableIrohaChainListener4J(@NonNull RMQConfig rmqConfig,
                                         @NonNull String irohaQueue,
-                                        @NonNull ExecutorService consumerExecutorService,
                                         boolean autoAck,
                                         @NonNull Runnable onRMQFail) {
         reliableIrohaChainListener = new ReliableIrohaChainListener(
                 rmqConfig,
                 irohaQueue,
-                consumerExecutorService,
                 autoAck, () -> {
             onRMQFail.run();
             return Unit.INSTANCE;
@@ -78,7 +73,7 @@ public class ReliableIrohaChainListener4J implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         reliableIrohaChainListener.close();
     }
 }

--- a/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterAuthIntegrationTest.kt
+++ b/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterAuthIntegrationTest.kt
@@ -50,9 +50,6 @@ class ChainAdapterAuthIntegrationTest {
             ReliableIrohaChainListener(
                 environment.mapToRMQConfig(adapter.chainAdapterConfig),
                 queueName,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 autoAck = true,
                 onRmqFail = {}
             ).use { reliableChainListener ->
@@ -101,9 +98,6 @@ class ChainAdapterAuthIntegrationTest {
                 ReliableIrohaChainListener(
                     modifiedConfig,
                     queueName,
-                    createPrettySingleThreadPool(
-                        CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                    ),
                     autoAck = true,
                     onRmqFail = {}
                 )

--- a/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterIntegrationTest.kt
+++ b/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterIntegrationTest.kt
@@ -5,10 +5,8 @@
 
 package integration.chainadapter
 
-import com.d3.chainadapter.CHAIN_ADAPTER_SERVICE_NAME
 import com.d3.chainadapter.client.ReliableIrohaChainListener
 import com.d3.chainadapter.client.ReliableIrohaChainListener4J
-import com.d3.commons.util.createPrettySingleThreadPool
 import com.d3.commons.util.getRandomString
 import com.github.kittinunf.result.failure
 import integration.chainadapter.environment.ChainAdapterIntegrationTestEnvironment
@@ -46,9 +44,6 @@ class ChainAdapterIntegrationTest {
             ReliableIrohaChainListener(
                 environment.mapToRMQConfig(adapter.chainAdapterConfig),
                 queueName,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 autoAck = true,
                 onRmqFail = {}
             ).use { reliableChainListener ->
@@ -91,9 +86,6 @@ class ChainAdapterIntegrationTest {
             ReliableIrohaChainListener(
                 environment.mapToRMQConfig(adapter.chainAdapterConfig),
                 queueName,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 autoAck = false,
                 onRmqFail = {}
             ).use { reliableChainListener ->
@@ -130,9 +122,6 @@ class ChainAdapterIntegrationTest {
             ReliableIrohaChainListener(
                 environment.mapToRMQConfig(adapter.chainAdapterConfig),
                 queueName,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 autoAck = false,
                 onRmqFail = {}
             ).use { reliableChainListener ->
@@ -176,9 +165,6 @@ class ChainAdapterIntegrationTest {
             ReliableIrohaChainListener4J(
                 environment.mapToRMQConfig(adapter.chainAdapterConfig),
                 queueName,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 false,
                 {}
             ).use { reliableChainListener ->

--- a/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterPregeneratedQueuesIntegrationTest.kt
+++ b/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterPregeneratedQueuesIntegrationTest.kt
@@ -5,9 +5,7 @@
 
 package integration.chainadapter
 
-import com.d3.chainadapter.CHAIN_ADAPTER_SERVICE_NAME
 import com.d3.chainadapter.client.ReliableIrohaChainListener
-import com.d3.commons.util.createPrettySingleThreadPool
 import com.github.kittinunf.result.failure
 import integration.chainadapter.environment.ChainAdapterIntegrationTestEnvironment
 import mu.KLogging
@@ -52,9 +50,6 @@ class ChainAdapterPregeneratedQueuesIntegrationTest {
             ReliableIrohaChainListener(
                 environment.mapToRMQConfig(chainAdapter.chainAdapterConfig),
                 queue,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 autoAck = true,
                 onRmqFail = {}
             ).use { reliableChainListener ->

--- a/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterUnreadIntegrationTest.kt
+++ b/chain-adapter/src/integration-test/kotlin/integration/chainadapter/ChainAdapterUnreadIntegrationTest.kt
@@ -5,9 +5,7 @@
 
 package integration.chainadapter
 
-import com.d3.chainadapter.CHAIN_ADAPTER_SERVICE_NAME
 import com.d3.chainadapter.client.ReliableIrohaChainListener
-import com.d3.commons.util.createPrettySingleThreadPool
 import com.d3.commons.util.getRandomString
 import com.github.kittinunf.result.failure
 import integration.chainadapter.environment.ChainAdapterIntegrationTestEnvironment
@@ -46,9 +44,6 @@ class ChainAdapterUnreadIntegrationTest {
             ReliableIrohaChainListener(
                 environment.mapToRMQConfig(adapter.chainAdapterConfig),
                 queueName,
-                createPrettySingleThreadPool(
-                    CHAIN_ADAPTER_SERVICE_NAME, "iroha-blocks-consumer"
-                ),
                 autoAck = true,
                 onRmqFail = {}
             ).use { reliableChainListener ->


### PR DESCRIPTION
`ableToHandleBlock` function may misbehave in a multi-threaded environment. For that reason, a single-threaded `ExecutorService` is used to call the function. If you want to handle blocks in a separate thread, just use `observeOn()`.