### PR TITLE
[DOPS-984] Move soramitsu docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             steps {
                 script {
                     if (env.BRANCH_NAME in dockerTags) {
-                        withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
+                        withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
                             env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                             env.TAG = dockerTags[env.BRANCH_NAME]
                             sh "./gradlew dockerPush"
@@ -69,7 +69,7 @@ pipeline {
                             sh "./gradlew dockerPush"
                         }
                     } else if (env.TAG_NAME ==~ /^\d.*/) {
-                        withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
+                        withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
                             env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                             env.TAG = env.TAG_NAME
                             sh "./gradlew dockerPush"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,12 +51,12 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME in dockerTags) {
                         withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/soramitsu"
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                             env.TAG = dockerTags[env.BRANCH_NAME]
                             sh "./gradlew dockerPush"
                         }
                         withCredentials([usernamePassword(credentialsId: 'nexus-nbc-deploy', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/bakong"
+                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19000"
                             env.TAG = dockerTags[env.BRANCH_NAME]
                             sh "./gradlew dockerPush"
                         }
@@ -64,13 +64,13 @@ pipeline {
                         def tagPattern = (env.TAG_NAME =~ /(?<=bakong-)(\d{1,4}\.\d.*)/)[0][1]
                         println "${tagPattern}"
                         withCredentials([usernamePassword(credentialsId: 'nexus-nbc-deploy', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/bakong"
+                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19000"
                             env.TAG = "${tagPattern}"
                             sh "./gradlew dockerPush"
                         }
                     } else if (env.TAG_NAME ==~ /^\d.*/) {
                         withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/soramitsu"
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                             env.TAG = env.TAG_NAME
                             sh "./gradlew dockerPush"
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,12 +51,12 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME in dockerTags) {
                         withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19004"
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/soramitsu"
                             env.TAG = dockerTags[env.BRANCH_NAME]
                             sh "./gradlew dockerPush"
                         }
                         withCredentials([usernamePassword(credentialsId: 'nexus-nbc-deploy', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19000"
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/bakong"
                             env.TAG = dockerTags[env.BRANCH_NAME]
                             sh "./gradlew dockerPush"
                         }
@@ -64,13 +64,13 @@ pipeline {
                         def tagPattern = (env.TAG_NAME =~ /(?<=bakong-)(\d{1,4}\.\d.*)/)[0][1]
                         println "${tagPattern}"
                         withCredentials([usernamePassword(credentialsId: 'nexus-nbc-deploy', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19000"
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/bakong"
                             env.TAG = "${tagPattern}"
                             sh "./gradlew dockerPush"
                         }
                     } else if (env.TAG_NAME ==~ /^\d.*/) {
                         withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19004"
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp/soramitsu"
                             env.TAG = env.TAG_NAME
                             sh "./gradlew dockerPush"
                         }


### PR DESCRIPTION
# Task

[DOPS-984]: Move soramitsu docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-984]: https://soramitsu.atlassian.net/browse/DOPS-984