### PR TITLE
[DOPS-984] Move soramitsu docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,8 @@ pipeline {
             steps {
                 script {
                     if (env.BRANCH_NAME in dockerTags) {
-                        withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19004"
+                        withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                             env.TAG = dockerTags[env.BRANCH_NAME]
                             sh "./gradlew dockerPush"
                         }
@@ -69,8 +69,8 @@ pipeline {
                             sh "./gradlew dockerPush"
                         }
                     } else if (env.TAG_NAME ==~ /^\d.*/) {
-                        withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                            env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19004"
+                        withCredentials([usernamePassword(credentialsId: 'bot-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
+                            env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                             env.TAG = env.TAG_NAME
                             sh "./gradlew dockerPush"
                         }


### PR DESCRIPTION
# Task

[DOPS-984]: Move soramitsu docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-984]: https://soramitsu.atlassian.net/browse/DOPS-984